### PR TITLE
Minor improvements of the plasticity tutorial

### DIFF
--- a/notebooks/plasticity/plasticity.ipynb
+++ b/notebooks/plasticity/plasticity.ipynb
@@ -1,12 +1,10 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "## Von-Mises elasto-plasticity"
+    "## Von Mises elasto-plasticity"
    ]
   },
   {
@@ -34,7 +32,7 @@
    "source": [
     "## Introduction\n",
     "\n",
-    "This example is concerned with the incremental analysis of an elasto-plastic von Mises material. The structure response is computed using an iterative predictor-corrector return mapping algorithm embedded in a nonlinear solver. Due to the simple expression of the von Mises criterion, the return mapping procedure is completely analytical (with linear isotropic hardening), and we can use a SNES type solver instead of a manual Newton method.\n"
+    "This example is concerned with the incremental analysis of an elasto-plastic von Mises material. The structure response is computed using an iterative predictor-corrector return mapping algorithm embedded in a nonlinear solver. Due to the simple expression of the von Mises criterion, the return mapping procedure is completely analytical (with linear isotropic hardening), so instead of using manual implementation of the Newton method, we can use an efficient one provided by the SNES library."
    ]
   },
   {
@@ -518,8 +516,7 @@
    "source": [
     "new_sig_tr, new_sig_dev, dp_ = compute_new_state(du, sig, p)\n",
     "residual_u = ufl.inner(new_sig_tr, eps(v)) * dx_m + ufl.inner(new_sig_dev, eps(v)) * dx #- F_ext(v) \n",
-    "J_u = ufl.derivative(residual_u, du, u_)\n",
-    "\n"
+    "J_u = ufl.derivative(residual_u, du, u_)"
    ]
   },
   {
@@ -1042,6 +1039,10 @@
     "load_steps = np.linspace(0, 1.1, Nincr+1)[1:] ** 0.5\n",
     "results = np.zeros((Nincr+1, 2))\n",
     "\n",
+    "# Computing UFL-expressions of the corrected stress tensor and the plastic variable.\n",
+    "# These expressions will be updated on each loading step.\n",
+    "new_sig_tr, new_sig_dev, dp_= compute_new_state(du, sig, p)\n",
+    "\n",
     "for i, t in enumerate(load_steps):\n",
     "    loading.value = t * q_lim\n",
     "    du.x.array[:] = 0.\n",
@@ -1051,7 +1052,6 @@
     "    print(\"Number of iterations : \", out[0])\n",
     "    print(f\"Converged reason = {out[1]:1.3f}\")\n",
     "\n",
-    "    new_sig_tr, new_sig_dev, dp_= compute_new_state(du, sig, p)\n",
     "    interpolate_quadrature(tensor_to_vector(new_sig_dev + new_sig_tr), sig)\n",
     "    interpolate_quadrature(p + dp_, p)\n",
     "\n",
@@ -1122,7 +1122,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.10.6"
   },
   "orig_nbformat": 4
  },


### PR DESCRIPTION
Main changes:
* converted the very first cell into a markdown one.
* slightly changed the introduction cell (manual Newton -> manual implementation of Newton).
* pulled the line `new_sig_tr, new_sig_dev, dp_= compute_new_state(du, sig, p)` out of the main loop. We don't need to calculate the same ufl-expressions on each loading step, as they remain the same during the hole modelling. Only their coefficients `sig`, `du` and `p` will change, but we take it into account in the `interpolate_quadrature` function. It slightly accelerates the algorithm. 
* removed some empty cells and lines.